### PR TITLE
Update the instruction in the DP application README

### DIFF
--- a/differential_privacy/privacy-preserving_research_data_sharing/README.md
+++ b/differential_privacy/privacy-preserving_research_data_sharing/README.md
@@ -43,11 +43,9 @@ Open your terminal and enter the following commands:
 
 ```
 pip install smartnoise-synth
-pip install openDP==0.6.2
+pip install openDP
 pip install swifter
 ```
-
-> **Note:** When running `pip install openDP==0.6.2`, you may see an error in red indicating that `smartnoise-synth` requires `openDP` version to be `>= 0.7.0`. However, due to the lack of a specific API required by `smartnoise-synth` in `openDP` versions after `0.7.0`, we choose to install version `0.6.2`.
 
 ### Step 2: Clone the Sample Code
 


### PR DESCRIPTION
Please refer to #10 

Tested with the latest version of smartnoise (1.0.2) and openDP (0.7.0).

In the previous version of smartnoise (1.0.1), running the DP application with openDP 0.7.0 would crash since smartnoise uses the API abandoned by openDP 0.7.0. Now, smartnoise 1.0.2 has [fixed this issue](https://github.com/opendp/smartnoise-sdk/commit/ab897db3366bc2aabdf1b99f93d1ada0f7af9ab4#diff-d330d79e53ddc174802646f2f3846ac3420e83383af32062dee32a81cbcacbc5).